### PR TITLE
【Fixed】`rails g` コマンドの際にhelper と assets ファイルが生成されないよう設定を追記

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,10 @@ module Blogs
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.generators do |g|
+      g.assets false
+      g.helper false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
#1
・`rails g` コマンドの際にhelper と assets ファイルが生成されないよう設定を追記